### PR TITLE
feat(release): add Aqua and UBI CLI installation support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,3 +35,106 @@ jobs:
       # The release-please action creates the git tag when a release PR is merged
       # This tag will automatically trigger the existing release.yml workflow
       # No additional workflow dispatch needed since release.yml triggers on tags matching 'v*.*.*'
+
+  upload-cli-binaries:
+    name: Upload CLI binaries to release 📦
+    # Only run when release-please creates a release
+    if: ${{ needs.release-please.outputs.release_created }}
+    needs: [release-please]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to upload release assets
+      actions: read # Required to download artifacts from other workflows
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Wait for release workflow to complete
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${{ needs.release-please.outputs.tag_name }}"
+          echo "Waiting for release workflow to complete for tag: $TAG_NAME"
+
+          # Wait for the release workflow to finish
+          # The release workflow is triggered by the tag creation
+          max_attempts=60  # Wait up to 30 minutes (60 * 30s)
+          attempt=0
+
+          while [ $attempt -lt $max_attempts ]; do
+            echo "Checking for release workflow run... (attempt $((attempt + 1))/$max_attempts)"
+
+            # Find workflow runs for the tag
+            WORKFLOW_ID=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name == "Release") | .id')
+
+            if [ -n "$WORKFLOW_ID" ]; then
+              # Check for completed runs
+              COMPLETED_RUNS=$(gh api "repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs" \
+                --jq "[.workflow_runs[] | select(.head_sha == \"$(git rev-parse $TAG_NAME)\") | select(.status == \"completed\")] | length")
+
+              if [ "$COMPLETED_RUNS" -gt 0 ]; then
+                echo "✅ Release workflow completed!"
+                break
+              fi
+            fi
+
+            echo "Release workflow still running, waiting 30 seconds..."
+            sleep 30
+            attempt=$((attempt + 1))
+          done
+
+          if [ $attempt -eq $max_attempts ]; then
+            echo "❌ Timeout waiting for release workflow to complete"
+            exit 1
+          fi
+
+      - name: Download CLI archives from release workflow
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${{ needs.release-please.outputs.tag_name }}"
+
+          # Find the workflow run for this tag
+          WORKFLOW_ID=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name == "Release") | .id')
+          RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs" \
+            --jq ".workflow_runs[] | select(.head_sha == \"$(git rev-parse $TAG_NAME)\") | select(.status == \"completed\") | .id" | head -1)
+
+          echo "Found release workflow run ID: $RUN_ID"
+
+          # Create directory for archives
+          mkdir -p cli-archives
+
+          # Download all CLI archive artifacts
+          gh run download "$RUN_ID" --pattern "cli-archive-*" --dir cli-archives-temp/
+
+          # Organize the downloaded archives
+          find cli-archives-temp -name "*.tar.gz" -o -name "*.zip" -o -name "*.sha256" | while read file; do
+            cp "$file" cli-archives/
+          done
+
+          echo "Downloaded CLI archives:"
+          ls -la cli-archives/
+
+      - name: Upload CLI archives to GitHub Release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${{ needs.release-please.outputs.tag_name }}"
+
+          # Upload each archive and checksum to the release
+          for file in cli-archives/*; do
+            if [[ -f "$file" ]]; then
+              filename=$(basename "$file")
+              echo "Uploading: $filename"
+              gh release upload "$TAG_NAME" "$file" --clobber
+              echo "✅ Uploaded: $filename"
+            fi
+          done
+
+          echo "All CLI binaries uploaded to release: $TAG_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,160 @@ jobs:
           path: dist/
           retention-days: 7 # Clean up after 7 days to prevent confusion
 
+      - name: Create CLI binary archive
+        shell: bash
+        run: |
+          # Get binary name and version
+          RUST_TARGET="${{ matrix.platform.rust_target }}"
+          VERSION=$(grep -A 1 "workspace.package" Cargo.toml | grep "version" | cut -d'"' -f2)
+          BINARY_NAME="serpen"
+
+          if [[ "$RUST_TARGET" == *"windows"* ]]; then
+            BINARY_NAME="serpen.exe"
+          fi
+
+          # Map Rust targets to Aqua/UBI compatible naming
+          case "$RUST_TARGET" in
+            "x86_64-unknown-linux-gnu")
+              OS="linux"
+              ARCH="x86_64"
+              EXT="tar.gz"
+              ;;
+            "x86_64-unknown-linux-musl")
+              OS="linux"
+              ARCH="x86_64"
+              EXT="tar.gz"
+              SUFFIX="-musl"
+              ;;
+            "aarch64-unknown-linux-gnu")
+              OS="linux"
+              ARCH="arm64"
+              EXT="tar.gz"
+              ;;
+            "aarch64-unknown-linux-musl")
+              OS="linux"
+              ARCH="arm64"
+              EXT="tar.gz"
+              SUFFIX="-musl"
+              ;;
+            "x86_64-apple-darwin")
+              OS="darwin"
+              ARCH="x86_64"
+              EXT="tar.gz"
+              ;;
+            "aarch64-apple-darwin")
+              OS="darwin"
+              ARCH="arm64"
+              EXT="tar.gz"
+              ;;
+            "x86_64-pc-windows-msvc")
+              OS="windows"
+              ARCH="x86_64"
+              EXT="zip"
+              ;;
+            "aarch64-pc-windows-msvc")
+              OS="windows"
+              ARCH="arm64"
+              EXT="zip"
+              ;;
+            *)
+              echo "Unknown target: $RUST_TARGET"
+              exit 1
+              ;;
+          esac
+
+          # Create archive name with version
+          ARCHIVE_NAME="serpen_${VERSION}_${OS}_${ARCH}${SUFFIX:-}.${EXT}"
+          echo "Creating archive: $ARCHIVE_NAME"
+
+          # Create archive directory
+          mkdir -p cli-archives
+
+          # Create archive based on platform
+          cd "target/npm-binaries/$RUST_TARGET"
+          if [[ "$EXT" == "zip" ]]; then
+            # Windows: use zip
+            if command -v powershell &> /dev/null; then
+              powershell -Command "Compress-Archive -Path '$BINARY_NAME' -DestinationPath '../../../cli-archives/$ARCHIVE_NAME'"
+            else
+              zip "../../../cli-archives/$ARCHIVE_NAME" "$BINARY_NAME"
+            fi
+          else
+            # Unix: use tar.gz
+            tar -czf "../../../cli-archives/$ARCHIVE_NAME" "$BINARY_NAME"
+          fi
+
+          cd - > /dev/null
+          echo "Archive created: cli-archives/$ARCHIVE_NAME"
+          ls -la "cli-archives/$ARCHIVE_NAME"
+
+      - name: Generate SHA256 checksum
+        shell: bash
+        run: |
+          # Get archive info
+          RUST_TARGET="${{ matrix.platform.rust_target }}"
+          VERSION=$(grep -A 1 "workspace.package" Cargo.toml | grep "version" | cut -d'"' -f2)
+
+          # Map target to archive naming (same logic as above)
+          case "$RUST_TARGET" in
+            "x86_64-unknown-linux-gnu")
+              ARCHIVE_NAME="serpen_${VERSION}_linux_x86_64.tar.gz"
+              ;;
+            "x86_64-unknown-linux-musl")
+              ARCHIVE_NAME="serpen_${VERSION}_linux_x86_64-musl.tar.gz"
+              ;;
+            "aarch64-unknown-linux-gnu")
+              ARCHIVE_NAME="serpen_${VERSION}_linux_arm64.tar.gz"
+              ;;
+            "aarch64-unknown-linux-musl")
+              ARCHIVE_NAME="serpen_${VERSION}_linux_arm64-musl.tar.gz"
+              ;;
+            "x86_64-apple-darwin")
+              ARCHIVE_NAME="serpen_${VERSION}_darwin_x86_64.tar.gz"
+              ;;
+            "aarch64-apple-darwin")
+              ARCHIVE_NAME="serpen_${VERSION}_darwin_arm64.tar.gz"
+              ;;
+            "x86_64-pc-windows-msvc")
+              ARCHIVE_NAME="serpen_${VERSION}_windows_x86_64.zip"
+              ;;
+            "aarch64-pc-windows-msvc")
+              ARCHIVE_NAME="serpen_${VERSION}_windows_arm64.zip"
+              ;;
+          esac
+
+          # Generate checksum
+          cd cli-archives
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # Windows: use certutil
+            certutil -hashfile "$ARCHIVE_NAME" SHA256 > checksum.txt
+            # Extract just the hash
+            grep -v "hash\|CertUtil" checksum.txt | tr -d '\r\n ' > "${ARCHIVE_NAME}.sha256"
+            # Add filename to match standard format
+            echo "  $ARCHIVE_NAME" >> "${ARCHIVE_NAME}.sha256"
+          else
+            # Unix: use sha256sum or shasum
+            if command -v sha256sum &> /dev/null; then
+              sha256sum "$ARCHIVE_NAME" > "${ARCHIVE_NAME}.sha256"
+            elif command -v shasum &> /dev/null; then
+              shasum -a 256 "$ARCHIVE_NAME" > "${ARCHIVE_NAME}.sha256"
+            else
+              echo "No SHA256 utility found"
+              exit 1
+            fi
+          fi
+
+          cd - > /dev/null
+          echo "Checksum created for: $ARCHIVE_NAME"
+          cat "cli-archives/${ARCHIVE_NAME}.sha256"
+
+      - name: Store CLI archive and checksum
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cli-archive-${{ matrix.platform.target }}-${{ github.run_id }}
+          path: cli-archives/
+          retention-days: 7
+
       - name: Store npm binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,54 @@ npx serpen --help
 
 > **🔐 Supply Chain Security**: All npm packages include [provenance attestations](docs/NPM_PROVENANCE.md) for enhanced security and verification.
 
+### Binary Downloads
+
+Download pre-built binaries for your platform from the [latest release](https://github.com/tinovyatkin/serpen/releases/latest):
+
+- **Linux x86_64**: `serpen_*_linux_x86_64.tar.gz`
+- **Linux ARM64**: `serpen_*_linux_arm64.tar.gz`
+- **macOS x86_64**: `serpen_*_darwin_x86_64.tar.gz`
+- **macOS ARM64**: `serpen_*_darwin_arm64.tar.gz`
+- **Windows x86_64**: `serpen_*_windows_x86_64.zip`
+- **Windows ARM64**: `serpen_*_windows_arm64.zip`
+
+Each binary includes a SHA256 checksum file for verification.
+
+### Package Manager Installation
+
+#### Aqua
+
+If you use [Aqua](https://aquaproj.github.io/), add to your `aqua.yaml`:
+
+```yaml
+registries:
+  - type: standard
+    ref: latest
+packages:
+  - name: tinovyatkin/serpen@latest
+```
+
+Then run:
+
+```bash
+aqua install
+```
+
+#### UBI (Universal Binary Installer)
+
+Using [UBI](https://github.com/houseabsolute/ubi):
+
+```bash
+# Install latest version
+ubi --project tinovyatkin/serpen
+
+# Install specific version
+ubi --project tinovyatkin/serpen --tag v0.4.1
+
+# Install to specific directory
+ubi --project tinovyatkin/serpen --in /usr/local/bin
+```
+
 ### From Source
 
 ```bash


### PR DESCRIPTION
## Summary
This PR adds support for Aqua and UBI CLI installation methods by enhancing the release workflow to produce multi-platform CLI binaries with proper naming conventions and checksums.

## Changes
- **Multi-platform binary archiving**: Create `.tar.gz` (Unix) and `.zip` (Windows) archives for all platforms
- **SHA256 checksums**: Generate integrity verification files for all binaries  
- **GitHub Release integration**: Upload CLI archives to releases via release-please workflow
- **Aqua/UBI compatible naming**: Use standardized `serpen_{version}_{os}_{arch}.{ext}` format
- **Documentation updates**: Add installation instructions for Aqua and UBI in README

## Supported Platforms
- Linux: x86_64, ARM64 (both GNU and musl libc)
- macOS: x86_64, ARM64 (Apple Silicon)
- Windows: x86_64, ARM64

## Installation Methods Added

### Aqua
```yaml
packages:
  - name: tinovyatkin/serpen@latest
```

### UBI (Universal Binary Installer)
```bash
ubi --project tinovyatkin/serpen
```

### Direct Binary Download
Pre-built binaries available from GitHub Releases with SHA256 checksums for verification.

## Implementation Details
- Extended existing multi-platform build matrix in `release.yml`
- Added binary archiving and checksum generation steps
- Created new `upload-cli-binaries` job in `release-please.yml` that:
  - Waits for release workflow completion
  - Downloads CLI archive artifacts
  - Uploads them to the GitHub Release created by release-please
- Updated README with comprehensive installation instructions

## Test Plan
- [ ] Verify workflow syntax and job dependencies
- [ ] Test archive creation on all platforms  
- [ ] Validate checksum generation
- [ ] Confirm release asset upload functionality
- [ ] Test Aqua installation once registry entry is added
- [ ] Test UBI installation with actual release

🤖 Generated with [Claude Code](https://claude.ai/code)